### PR TITLE
Keep processing on notify failures

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -3,7 +3,6 @@
 // Retry queue logic using Mongo
 
 const Promise = require('bluebird');
-const R = require('ramda');
 const queueDb = require('./db');
 const utils = require('./utils');
 
@@ -131,7 +130,12 @@ module.exports = function(opts) {
   function processRecord(record) {
     // If retryLimit is negative, then we'll retry forever
     if (recordHasFailed(record)) {
-      return notifyFailedRecord(record);
+      return notifyFailedRecord(record).catch(function(err) {
+        console.error(
+          '[MONGO-QUEUE] Failure notifying record -- will try later;',
+          err.stack || err
+        );
+      });
     } else {
       return Promise.resolve()
         .then(function() {
@@ -208,8 +212,7 @@ module.exports = function(opts) {
     // If not continueProcesssingOnError, then we need to make sure that the failed
     //  record is the first to be processed each batch.
     // (Should only be one...)
-    const isFailed = R.propEq('status', STATUS_CODES.failed);
-    const firstFailed = R.find(isFailed, records);
+    const firstFailed = records.find((record) => record.status === STATUS_CODES.failed);
 
     if (firstFailed && firstFailed.available > new Date()) {
       // If there's a failed record, and it's not available, we can't process anything

--- a/lib/queue.test.js
+++ b/lib/queue.test.js
@@ -271,6 +271,33 @@ describe(__filename, function() {
         });
     });
 
+    it('Should not let a failure to nofity stop processing of other records', function() {
+      onProcessStub.onCall(0).rejects(new Error('boo')); // First record will fail
+      onProcessStub.onCall(1).resolves(); // Second record will pass
+      onProcessStub.onCall(2).resolves(); // Third record will pass
+      onFailureStub.rejects(new Error('Error in notify'));
+
+      const queue = createQueue({
+        batchSize: 2
+      });
+
+      return queue
+        .enqueue({ foo: 1 })
+        .then(() => queue.enqueue({ foo: 2 }))
+        .then(() => queue.enqueue({ foo: 3 }))
+        .then(() => queue.processNextBatch())
+        .then(() => {
+          expect(onProcessStub.callCount).toEqual(2); // Should have processed 2 records (batch size) -- the first will have failed
+        })
+        .then(() => queue.processNextBatch()) // Re-process the first, and also process the third record
+        .then(() => {
+          expect(onFailureStub.callCount).toEqual(1); // First record should have been passed to onFailure()
+          expect(onFailureStub.getCall(0).args[0]).toInclude({ data: { foo: 1 } });
+
+          expect(onProcessStub.callCount).toEqual(3); // Should have still continued on to processed the third record
+        });
+    });
+
     it('Should backoff exponentially on errors', function() {
       onProcessStub.rejects(new Error('boo'));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-queue",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Use mongo as a persistent queue",
   "main": "lib/index.js",
   "scripts": {
@@ -12,8 +12,7 @@
   "dependencies": {
     "bluebird": "~3.4.6",
     "cron-master": "~0.3.0",
-    "mongodb": "~2.1.21",
-    "ramda": "^0.23.0"
+    "mongodb": "~2.1.21"
   },
   "devDependencies": {
     "eslint": "~3.18.0",
@@ -26,6 +25,7 @@
     "prettier": "~1.2.2",
     "prettier-eslint-cli": "~3.4.2",
     "proxyquire": "0.5.3",
+    "ramda": "^0.23.0",
     "sinon": "~1.17.2",
     "sinon-as-promised": "~4.0.2"
   },


### PR DESCRIPTION
Currently, if there's a failure in the onFailure event, it won't process any new records, even though this record is dead and it shouldn't affect processing of others.

With this implementation, it will retry onFailure() on every tick of the cron. The process will appear to hang if ever there are N failed records trying to be processed in onFailure(), where N is the batch size.